### PR TITLE
remove node prefix in EcrLoginPassword require for node v15 compatibility

### DIFF
--- a/EcrLoginPassword.js
+++ b/EcrLoginPassword.js
@@ -1,6 +1,6 @@
 const get = require('rubico/get')
 const callProp = require('rubico/x/callProp')
-const { exec } = require('node:child_process')
+const { exec } = require('child_process')
 const streamToString = require('./internal/streamToString')
 
 /**


### PR DESCRIPTION
quick fix instead of debugging node 18 installation inside ec2 instances