### PR TITLE
enable DockerService replicas 'global' option

### DIFF
--- a/Docker.js
+++ b/Docker.js
@@ -873,10 +873,12 @@ Docker.prototype.createService = function dockerCreateService(service, options) 
         },
       },
 
-      // TODO options.mode global
-      Mode: {
+      Mode: options.replicas == 'global' ? {
+        Global: {},
+      } : {
         Replicated: { Replicas: options.replicas ?? 1 }
       },
+
       UpdateConfig: fork({
         Parallelism: get('updateParallelism', 2),
         Delay: get('updateDelay', 1e9),

--- a/Docker.test.js
+++ b/Docker.test.js
@@ -401,7 +401,7 @@ EXPOSE 8888`,
     { // listTasks
       const response = await docker.listTasks()
       const body = await response.json()
-      assert.equal(body.length, 4) // 2 for hey1, 2 for hey2
+      assert.equal(body.length, 3) // 2 for hey1, 1 for hey2 (global)
     }
 
     { // inspectService

--- a/Docker.test.js
+++ b/Docker.test.js
@@ -373,7 +373,7 @@ EXPOSE 8888`,
     { // create another service
       const response = await docker.createService('hey2', {
         image: 'node:15-alpine',
-        replicas: 2,
+        replicas: 'global',
         cmd: ['node', '-e', 'http.createServer((request, response) => response.end(\'hey2\')).listen(3001)'],
         workdir: '/opt/heyo',
         env: { HEY: 'hey' },

--- a/DockerService.js
+++ b/DockerService.js
@@ -47,7 +47,7 @@ const dockerServiceOptions = [
  * new DockerService({
  *   name: string,
  *   image: string,
- *   replicas: 1|number,
+ *   replicas: 'global'|1|number,
  *   restart: 'no'|'on-failure[:<max-retries>]'|'any',
  *   restartDelay: 10e9|number, // nanoseconds to delay between restarts
  *   logDriver: 'json-file'|'syslog'|'journald'|'gelf'|'fluentd'|'awslogs'|'splunk'|'none',
@@ -174,7 +174,7 @@ DockerService.prototype.synchronize = function dockerServiceSynchronize() {
  *   rollback: 'previous', // roll service back to previous version
  *
  *   image: string,
- *   replicas: 1|number,
+ *   replicas: 'global'|number,
  *   restart: 'no'|'on-failure[:<max-retries>]'|'any',
  *   restartDelay: 10e9|number, // nanoseconds to delay between restarts
  *   logDriver: 'json-file'|'syslog'|'journald'|'gelf'|'fluentd'|'awslogs'|'splunk'|'none',


### PR DESCRIPTION
Allows specifying 'global' for replicas in a DockerService so that each node gets a service automatically